### PR TITLE
Fix compilation with Nim 0.13.1

### DIFF
--- a/main.nim.cfg
+++ b/main.nim.cfg
@@ -6,6 +6,7 @@
 --noLinking
 
 --os:standalone
+--gc:none
 
 --deadCodeElim:on
 --noMain


### PR DESCRIPTION
Without the gc:none option, nim attempts to grab things from the C
stdlib.
