### PR TITLE
Updated to work with nim 1.6.0

### DIFF
--- a/ioutils.nim
+++ b/ioutils.nim
@@ -1,4 +1,3 @@
-import unsigned
 type
   PVIDMem* = ptr array[0..65_000, TEntry]
 

--- a/main.nim.cfg
+++ b/main.nim.cfg
@@ -1,7 +1,7 @@
 
 --cpu:i386
 --boundChecks:on
---passc:"-w -I$lib -ffreestanding -O2 -Wall -Wextra"
+--passc:"-w -I$lib -std=gnu99 -ffreestanding -O2 -Wall -Wextra"
 
 --noLinking
 

--- a/nakefile.nim
+++ b/nakefile.nim
@@ -2,8 +2,8 @@ import nake
 import os
 
 const
-  CC = "i586-elf-gcc"
-  asmC = "i586-elf-as"
+  CC = "i686-elf-gcc"
+  asmC = "i686-elf-as"
 
 task "clean", "Removes build files.":
   removeFile("boot.o")
@@ -13,13 +13,13 @@ task "clean", "Removes build files.":
 
 task "build", "Builds the operating system.":
   echo "Compiling..."
-  direShell "nim c -d:release --gcc.exe:$1 main.nim" % CC
+  direShell "nim c -d:release --nimcache:nimcache --gcc.exe:$1 main.nim" % CC
   
   direShell asmC, "boot.s -o boot.o"
   
   echo "Linking..."
   
-  direShell CC, "-T linker.ld -o main.bin -ffreestanding -O2 -nostdlib boot.o nimcache/main.o nimcache/stdlib_system.o nimcache/stdlib_unsigned.o nimcache/ioutils.o"
+  direShell CC, "-T linker.ld -o main.bin -ffreestanding -O2 -nostdlib boot.o nimcache/@mmain.nim.c.o nimcache/stdlib_system.nim.c.o nimcache/@mioutils.nim.c.o -lgcc"
   
   echo "Done."
   


### PR DESCRIPTION
Nim nolonger needs an external library for unsigned integers, so I removed the call for that library.
I forced the gnu99 dialect of c for compatibility, I'll work on getting a newer version to work later.
I changed i586-elf-* to i686-elf-* since that is the cross compiler I have and what osdev says to use. I also explicitly set nimcache since the default is outside the repo and it was less work to update the linker command. Nim has a different naming scheme for cached object files so I updated those in the linker command.